### PR TITLE
Add supervisor navigation links and dashboard shortcuts

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -21,6 +21,18 @@ body {
   color: #6c757d;
 }
 
+.quick-link-card {
+  border: 1px solid rgba(13, 110, 253, 0.1);
+  border-radius: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.quick-link-card:hover,
+.quick-link-card:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(13, 110, 253, 0.15);
+}
+
 .table thead th {
   white-space: nowrap;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,7 +16,45 @@
           <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
-          <ul class="navbar-nav ms-auto">
+          {% if current_user.is_authenticated %}
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              {% if current_user.is_supervisor() %}
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('supervisor.dashboard') }}">Panel</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('supervisor.teachers') }}">Öğretmenler</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('supervisor.courses_view') }}">Dersler</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('supervisor.classes_view') }}">Sınıflar</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('supervisor.students_view') }}">Öğrenciler</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('supervisor.attendance_overview') }}">Yoklamalar</a>
+                </li>
+              {% elif current_user.is_teacher() %}
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('teacher.dashboard') }}">Panel</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('teacher.create_attendance') }}">Yoklama Oluştur</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('teacher.history') }}">Yoklama Geçmişi</a>
+                </li>
+              {% elif current_user.is_student() %}
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('student.dashboard') }}">Panel</a>
+                </li>
+              {% endif %}
+            </ul>
+          {% endif %}
+          <ul class="navbar-nav ms-lg-auto mb-2 mb-lg-0">
             {% if current_user.is_authenticated %}
               <li class="nav-item"><span class="nav-link">{{ current_user.full_name }}</span></li>
               <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Çıkış</a></li>

--- a/app/templates/supervisor/dashboard.html
+++ b/app/templates/supervisor/dashboard.html
@@ -28,6 +28,48 @@
     </div>
   </div>
 </div>
+<div class="row row-cols-1 row-cols-md-3 row-cols-xl-5 g-3 mt-4">
+  <div class="col">
+    <a class="card h-100 text-center text-decoration-none text-dark quick-link-card" href="{{ url_for('supervisor.teachers') }}">
+      <div class="card-body">
+        <h5 class="card-title">Öğretmenler</h5>
+        <p class="card-text text-muted">Eğitmen kadrosunu yönetin.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card h-100 text-center text-decoration-none text-dark quick-link-card" href="{{ url_for('supervisor.courses_view') }}">
+      <div class="card-body">
+        <h5 class="card-title">Dersler</h5>
+        <p class="card-text text-muted">Ders bilgilerini düzenleyin.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card h-100 text-center text-decoration-none text-dark quick-link-card" href="{{ url_for('supervisor.classes_view') }}">
+      <div class="card-body">
+        <h5 class="card-title">Sınıflar</h5>
+        <p class="card-text text-muted">Sınıf ve şubeleri güncelleyin.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card h-100 text-center text-decoration-none text-dark quick-link-card" href="{{ url_for('supervisor.students_view') }}">
+      <div class="card-body">
+        <h5 class="card-title">Öğrenciler</h5>
+        <p class="card-text text-muted">Öğrenci kayıtlarını yönetin.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card h-100 text-center text-decoration-none text-dark quick-link-card" href="{{ url_for('supervisor.attendance_overview') }}">
+      <div class="card-body">
+        <h5 class="card-title">Yoklamalar</h5>
+        <p class="card-text text-muted">Yoklama kayıtlarına göz atın.</p>
+      </div>
+    </a>
+  </div>
+</div>
 <div class="card mt-4">
   <div class="card-header">Son Yoklamalar</div>
   <div class="card-body table-responsive">


### PR DESCRIPTION
## Summary
- add role-specific navigation menus to the base layout for supervisors, teachers, and students
- adjust navbar alignment to keep the new links available in the collapsed mobile view
- provide quick-access cards and hover styling on the supervisor dashboard

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcd22aa028832ba2c8b3e842c97354