### PR TITLE
Add UTF-8 BOM to attendance CSV exports

### DIFF
--- a/app/routes/supervisor.py
+++ b/app/routes/supervisor.py
@@ -499,7 +499,12 @@ def export_attendance_csv():
     records = _filtered_records()
     buffer = generate_csv(records)
     filename = f"yoklamalar_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.csv"
-    return send_file(buffer, as_attachment=True, download_name=filename, mimetype='text/csv')
+    return send_file(
+        buffer,
+        as_attachment=True,
+        download_name=filename,
+        mimetype='text/csv; charset=utf-8',
+    )
 
 
 @supervisor_bp.route('/yoklamalar/indir/pdf')

--- a/app/utils/exporters.py
+++ b/app/utils/exporters.py
@@ -35,7 +35,7 @@ def generate_csv(records: Iterable[AttendanceRecord]) -> io.BytesIO:
                 ]
             )
     buffer = io.BytesIO()
-    buffer.write(output.getvalue().encode('utf-8'))
+    buffer.write(output.getvalue().encode('utf-8-sig'))
     buffer.seek(0)
     return buffer
 


### PR DESCRIPTION
## Summary
- write attendance CSV exports with a UTF-8 BOM so Windows spreadsheet tools read Turkish characters correctly
- return the supervisor CSV download with an explicit UTF-8 charset in the mimetype header

## Testing
- python - <<'PY'
from app.utils.exporters import generate_csv
from datetime import datetime

class Simple:
    def __init__(self, **entries):
        self.__dict__.update(entries)

student = Simple(full_name='Çağrı Öztürk')
entry = Simple(student=student, status='present')
record = Simple(
    course=Simple(name='Türkçe'),
    classroom=Simple(name='1-A'),
    teacher=Simple(full_name='Ayşe Öğretmen'),
    session_date=datetime(2024, 5, 1, 9, 30),
    entries=[entry],
)

buffer = generate_csv([record])
data = buffer.getvalue()
print('BOM bytes:', data[:3])
print('Decoded preview:\n', data.decode('utf-8-sig'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68dcdc17b5d8832b8e1a25c8afe6dd45