### PR TITLE
Add automatic student credential generation and student password change page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Okullarda devamsızlık süreçlerini sade ve güvenli biçimde yönetmek için 
 - **Yönetici (Supervisor)**
   - Öğretmen, ders, sınıf ve öğrenci yönetimi (ekleme/düzenleme/silme).
   - CSV veya PDF formatındaki öğrenci listelerini içeri aktarma.
-  - Öğrenciler için isteğe bağlı olarak giriş hesabı (e-posta/şifre) oluşturma veya güncelleme.
+- Öğrenciler için isteğe bağlı olarak giriş hesabı (e-posta/şifre) oluşturma veya güncelleme.
+  - Boş bırakılan e-posta / şifre alanları için otomatik öğrenci kimlik bilgileri üretme.
   - Öğretmenlerin aldığı yoklamaları görüntüleme, filtreleme ve düzenleme.
   - Yoklama kayıtlarını CSV veya PDF olarak dışa aktarma.
 - **Öğretmen**
@@ -66,6 +67,13 @@ ad, soyad, okul_numarasi, sinif
 ```
 
 PDF içe aktarma özelliği; satırların bu başlıklarla yapılandırıldığı, tablo biçimindeki dokümanlar ile uyumludur.
+
+## Otomatik Öğrenci Hesapları ve İndirme
+
+- Yönetici panelinden öğrenci eklerken/düzenlerken e-posta veya şifre alanı boş bırakıldığında sistem otomatik olarak `ogrenci.okul` alan adında benzersiz bir e-posta ve güçlü bir şifre üretir.
+- Oluşturulan bilgiler, sayfanın üst kısmındaki "Oluşturulan Öğrenci Kimlik Bilgileri" kartında listelenir ve yalnızca mevcut oturum boyunca saklanır.
+- Kart üzerindeki **CSV Olarak İndir** bağlantısını kullanarak tüm üretilen kimlik bilgilerini tek seferde dışa aktarabilir, dosyayı güvenli biçimde paylaşabilirsiniz.
+- Listede hangi bilgilerin otomatik oluşturulduğu rozetlerle belirtilir; manuel girilen değerler "Hayır" olarak işaretlenir.
 
 ## Güvenlik Notları
 

--- a/app/routes/student.py
+++ b/app/routes/student.py
@@ -1,6 +1,8 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask_login import current_user
+from werkzeug.security import generate_password_hash
 
+from .. import db
 from ..models import Student, attendance_statistics_for_student
 from ..utils.decorators import role_required
 
@@ -37,3 +39,26 @@ def dashboard():
             }
         )
     return render_template('student/dashboard.html', student=student, stats=stats)
+
+
+@student_bp.route('/sifre', methods=['GET', 'POST'])
+@role_required('student')
+def change_password():
+    student = Student.query.filter_by(user_id=current_user.id).first_or_404()
+    if request.method == 'POST':
+        new_password = request.form.get('password', '').strip()
+        confirm_password = request.form.get('confirm_password', '').strip()
+
+        if not new_password:
+            flash('Yeni şifre girmelisiniz.', 'warning')
+        elif len(new_password) < 8:
+            flash('Şifreniz en az 8 karakter olmalıdır.', 'warning')
+        elif new_password != confirm_password:
+            flash('Şifreler eşleşmiyor.', 'danger')
+        else:
+            student.user.password_hash = generate_password_hash(new_password)
+            db.session.commit()
+            flash('Şifreniz başarıyla güncellendi.', 'success')
+            return redirect(url_for('student.change_password'))
+
+    return render_template('student/change_password.html', student=student)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -51,6 +51,9 @@
                 <li class="nav-item">
                   <a class="nav-link" href="{{ url_for('student.dashboard') }}">Panel</a>
                 </li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('student.change_password') }}">Şifre Değiştir</a>
+                </li>
               {% endif %}
             </ul>
           {% endif %}

--- a/app/templates/student/change_password.html
+++ b/app/templates/student/change_password.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block title %}Şifre Değiştir{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-6">
+    <div class="card shadow-sm">
+      <div class="card-header bg-primary text-white">
+        <h1 class="h4 mb-0">Şifre Değiştir</h1>
+      </div>
+      <div class="card-body">
+        <p class="mb-4">Merhaba {{ student.full_name }}, yeni şifrenizi oluşturmak için aşağıdaki formu doldurun.</p>
+        <form method="post" novalidate>
+          <div class="mb-3">
+            <label for="password" class="form-label">Yeni Şifre</label>
+            <input type="password" class="form-control" id="password" name="password" required minlength="8"
+                   placeholder="En az 8 karakter">
+            <div class="form-text">Büyük/küçük harf, rakam ve sembol içeren güçlü bir şifre seçin.</div>
+          </div>
+          <div class="mb-3">
+            <label for="confirm_password" class="form-label">Yeni Şifre (Tekrar)</label>
+            <input type="password" class="form-control" id="confirm_password" name="confirm_password" required minlength="8"
+                   placeholder="Şifreyi tekrar girin">
+          </div>
+          <div class="d-flex justify-content-end gap-2">
+            <a class="btn btn-outline-secondary" href="{{ url_for('student.dashboard') }}">İptal</a>
+            <button type="submit" class="btn btn-primary">Şifreyi Güncelle</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/supervisor/students.html
+++ b/app/templates/supervisor/students.html
@@ -30,6 +30,59 @@
     <button class="btn btn-secondary w-100" type="submit">Filtrele</button>
   </div>
 </form>
+{% if generated_credentials %}
+  <div class="card mb-4">
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+      <h2 class="h5 mb-0">Oluşturulan Öğrenci Kimlik Bilgileri</h2>
+      <a class="btn btn-outline-success" href="{{ url_for('supervisor.download_generated_credentials') }}">
+        CSV Olarak İndir
+      </a>
+    </div>
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-striped mb-0">
+          <thead>
+            <tr>
+              <th>Ad Soyad</th>
+              <th>Okul No</th>
+              <th>E-posta</th>
+              <th>Şifre</th>
+              <th class="text-center">E-posta Otomatik</th>
+              <th class="text-center">Şifre Otomatik</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for credential in generated_credentials %}
+              <tr>
+                <td>{{ credential.full_name }}</td>
+                <td>{{ credential.student_number }}</td>
+                <td><code>{{ credential.email }}</code></td>
+                <td><code>{{ credential.password }}</code></td>
+                <td class="text-center">
+                  {% if credential.auto_email %}
+                    <span class="badge bg-success">Evet</span>
+                  {% else %}
+                    <span class="badge bg-secondary">Hayır</span>
+                  {% endif %}
+                </td>
+                <td class="text-center">
+                  {% if credential.auto_password %}
+                    <span class="badge bg-success">Evet</span>
+                  {% else %}
+                    <span class="badge bg-secondary">Hayır</span>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="small text-muted px-3 py-2 border-top">
+        Bu bilgiler oturumunuz süresince saklanır. İndirme sonrası güvenli bir şekilde paylaşmayı unutmayın.
+      </div>
+    </div>
+  </div>
+{% endif %}
 <div class="table-responsive">
   <table class="table table-striped align-middle">
     <thead>

--- a/app/utils/accounts.py
+++ b/app/utils/accounts.py
@@ -1,0 +1,51 @@
+"""Utilities for managing account-related helpers."""
+from __future__ import annotations
+
+import secrets
+import string
+import unicodedata
+
+from typing import Tuple
+
+from ..models import User
+
+
+STUDENT_EMAIL_DOMAIN = 'ogrenci.okul'
+
+
+def _slugify(value: str) -> str:
+    """Create an ASCII slug from the given value using ``unicodedata``."""
+    if not value:
+        return ''
+    normalized = unicodedata.normalize('NFKD', value)
+    ascii_str = normalized.encode('ascii', 'ignore').decode('ascii')
+    cleaned = ''.join(ch if ch.isalnum() else '-' for ch in ascii_str.lower())
+    parts = [part for part in cleaned.split('-') if part]
+    return '-'.join(parts)
+
+
+def _generate_password(length: int = 12) -> str:
+    """Generate a cryptographically secure random password."""
+    alphabet = string.ascii_letters + string.digits + string.punctuation
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+
+def generate_student_credentials(full_name: str, student_number: str) -> Tuple[str, str]:
+    """Return a unique email and strong password for a student."""
+    slug = _slugify(full_name) or 'ogrenci'
+    base_local = f"{student_number}"
+    if slug:
+        base_local = f"{slug}.{student_number}"
+
+    counter = 0
+    while True:
+        suffix = f"-{counter}" if counter else ''
+        local_part = f"{base_local}{suffix}"
+        email_candidate = f"{local_part}@{STUDENT_EMAIL_DOMAIN}"
+        existing = User.query.filter_by(email=email_candidate).first()
+        if not existing:
+            break
+        counter += 1
+
+    password = _generate_password()
+    return email_candidate, password


### PR DESCRIPTION
## Summary
- add a utility to generate unique student credentials and integrate it into supervisor student add/edit flows with CSV export
- display generated student credentials in the supervisor UI with a download option and document the workflow in the README
- provide a dedicated student password change page and expose it in the navigation

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dce577dd74832bb6b6fd075f228606