### PR TITLE
Add Excel import support and enhance student import flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Okullarda devamsızlık süreçlerini sade ve güvenli biçimde yönetmek için 
 
 - **Yönetici (Supervisor)**
   - Öğretmen, ders, sınıf ve öğrenci yönetimi (ekleme/düzenleme/silme).
-  - CSV veya PDF formatındaki öğrenci listelerini içeri aktarma.
+  - CSV, Excel veya PDF formatındaki öğrenci listelerini içeri aktarma.
 - Öğrenciler için isteğe bağlı olarak giriş hesabı (e-posta/şifre) oluşturma veya güncelleme.
   - Boş bırakılan e-posta / şifre alanları için otomatik öğrenci kimlik bilgileri üretme.
   - Öğretmenlerin aldığı yoklamaları görüntüleme, filtreleme ve düzenleme.
@@ -58,7 +58,7 @@ Varsayılan olarak uygulama `http://127.0.0.1:5000` adresinde çalışır. Çal�
 
 Sistem tüm kullanıcılar için aynı giriş sayfasını kullanır; rol farkı giriş yaptıktan sonra otomatik olarak yönlendirilir.
 
-## CSV / PDF İçeri Aktarma Formatı
+## CSV / Excel / PDF İçeri Aktarma Formatı
 
 Dosyalar aşağıdaki başlıklara sahip bir tablo içermelidir:
 
@@ -66,7 +66,9 @@ Dosyalar aşağıdaki başlıklara sahip bir tablo içermelidir:
 ad, soyad, okul_numarasi, sinif
 ```
 
-PDF içe aktarma özelliği; satırların bu başlıklarla yapılandırıldığı, tablo biçimindeki dokümanlar ile uyumludur.
+CSV ve Excel dosyaları doğrudan aynı başlıkları içermelidir. PDF içe aktarma özelliği; satırların bu başlıklarla yapılandırıldığı, tablo biçimindeki dokümanlar ile uyumludur.
+
+> Not: Excel (`.xls` / `.xlsx`) içe aktarma desteği için uygulama `openpyxl` kütüphanesini kullanır. Bu bağımlılık `requirements.txt` dosyasına eklenmiştir; kurulum adımlarını izlediğinizde otomatik olarak yüklenecektir.
 
 ## Otomatik Öğrenci Hesapları ve İndirme
 

--- a/app/templates/supervisor/students.html
+++ b/app/templates/supervisor/students.html
@@ -4,7 +4,7 @@
 <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
   <h1 class="mb-0">Öğrenciler</h1>
   <div class="d-flex gap-2">
-    <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#importCsvModal">CSV'den Aktar</button>
+    <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#importCsvModal">CSV/Excel'den Aktar</button>
     <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#importPdfModal">PDF'den Aktar</button>
     <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addStudentModal">Öğrenci Ekle</button>
   </div>
@@ -30,6 +30,30 @@
     <button class="btn btn-secondary w-100" type="submit">Filtrele</button>
   </div>
 </form>
+{% if import_report %}
+  <div class="card mb-4">
+    <div class="card-header">
+      <h2 class="h5 mb-0">İçe Aktarma Sonucu</h2>
+    </div>
+    <div class="card-body">
+      <p class="mb-1">{{ import_report.source }} dosyasından toplam <strong>{{ import_report.total }}</strong> satır işlendi.</p>
+      <p class="mb-3">Kaydedilen öğrenci sayısı: <strong>{{ import_report.created }}</strong></p>
+      {% if import_report.skipped_rows %}
+        <div class="alert alert-warning mb-0">
+          <h3 class="h6 mb-2">Atlanan Satırlar</h3>
+          <ul class="mb-0">
+            {% for skipped in import_report.skipped_rows %}
+              <li>Satır {{ skipped.row }} &mdash; {{ skipped.reason }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% else %}
+        <div class="alert alert-success mb-0">Tüm satırlar başarıyla kaydedildi.</div>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}
+
 {% if generated_credentials %}
   <div class="card mb-4">
     <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
@@ -236,10 +260,10 @@
         <h5 class="modal-title">CSV'den Öğrenci Aktar</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-      <form method="post" action="{{ url_for('supervisor.import_students_csv') }}" enctype="multipart/form-data">
+      <form method="post" action="{{ url_for('supervisor.import_students') }}" enctype="multipart/form-data">
         <div class="modal-body">
-          <p class="mb-2">CSV dosyanızda şu başlıklar bulunmalıdır: <strong>ad, soyad, okul_numarasi, sinif</strong>.</p>
-          <input type="file" class="form-control" name="file" accept=".csv" required>
+          <p class="mb-2">CSV veya Excel dosyanızda şu başlıklar bulunmalıdır: <strong>ad, soyad, okul_numarasi, sinif</strong>.</p>
+          <input type="file" class="form-control" name="file" accept=".csv,.xls,.xlsx,application/pdf" required>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
@@ -257,10 +281,10 @@
         <h5 class="modal-title">PDF'den Öğrenci Aktar</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-      <form method="post" action="{{ url_for('supervisor.import_students_pdf') }}" enctype="multipart/form-data">
+      <form method="post" action="{{ url_for('supervisor.import_students') }}" enctype="multipart/form-data">
         <div class="modal-body">
-          <p class="mb-2">PDF içerisindeki tablo başlıkları: <strong>ad, soyad, okul_numarasi, sinif</strong> olmalıdır.</p>
-          <input type="file" class="form-control" name="file" accept="application/pdf" required>
+          <p class="mb-2">PDF içerisindeki tablo başlıkları: <strong>ad, soyad, okul_numarasi, sinif</strong> olmalıdır. Excel veya CSV yüklemek isterseniz diğer modalı da kullanabilirsiniz.</p>
+          <input type="file" class="form-control" name="file" accept=".csv,.xls,.xlsx,application/pdf" required>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>

--- a/app/utils/importers.py
+++ b/app/utils/importers.py
@@ -1,6 +1,6 @@
 import csv
 import io
-from typing import List, Dict
+from typing import Dict, List
 
 import pandas as pd
 import pdfplumber
@@ -10,42 +10,84 @@ REQUIRED_HEADERS = {'ad', 'soyad', 'okul_numarasi', 'sinif'}
 
 
 def parse_csv(file_storage) -> List[Dict[str, str]]:
+    """Parse a CSV file and return normalized student dictionaries."""
+    file_storage.stream.seek(0)
     data = file_storage.read().decode('utf-8-sig')
     reader = csv.DictReader(io.StringIO(data))
     headers = {h.strip().lower() for h in reader.fieldnames or []}
     if not REQUIRED_HEADERS.issubset(headers):
-        raise ValueError('CSV başlıkları eksik. Gerekli başlıklar: ad, soyad, okul_numarasi, sinif')
+        raise ValueError(
+            'CSV başlıkları eksik. Gerekli başlıklar: ad, soyad, okul_numarasi, sinif',
+        )
 
-    students = []
-    for row in reader:
+    students: List[Dict[str, str]] = []
+    for row_index, row in enumerate(reader, start=2):
         students.append(
             {
                 'full_name': f"{row.get('ad', '').strip()} {row.get('soyad', '').strip()}".strip(),
                 'student_number': str(row.get('okul_numarasi', '')).strip(),
                 'class_name': row.get('sinif', '').strip(),
+                'source_row': row_index,
             }
         )
     return students
 
 
 def parse_pdf(file_storage) -> List[Dict[str, str]]:
+    """Parse a PDF table and return normalized student dictionaries."""
+    file_storage.stream.seek(0)
     students: List[Dict[str, str]] = []
     with pdfplumber.open(file_storage) as pdf:
         for page in pdf.pages:
             table = page.extract_table()
             if not table:
                 continue
-            df = pd.DataFrame(table[1:], columns=[c.strip().lower() for c in table[0]])
+            headers = [c.strip().lower() for c in table[0]]
+            df = pd.DataFrame(table[1:], columns=headers).fillna('')
             if not REQUIRED_HEADERS.issubset(set(df.columns)):
                 continue
-            for _, row in df.iterrows():
+            for row_index, row in enumerate(df.to_dict(orient='records'), start=2):
                 students.append(
                     {
                         'full_name': f"{str(row.get('ad', '')).strip()} {str(row.get('soyad', '')).strip()}".strip(),
                         'student_number': str(row.get('okul_numarasi', '')).strip(),
                         'class_name': str(row.get('sinif', '')).strip(),
+                        'source_row': row_index,
                     }
                 )
     if not students:
         raise ValueError('PDF içeriği okunamadı. Lütfen tablo formatında olduğundan emin olun.')
+    return students
+
+
+def parse_excel(file_storage) -> List[Dict[str, str]]:
+    """Parse an Excel file (.xls/.xlsx) and return normalized student dictionaries."""
+    file_storage.stream.seek(0)
+    try:
+        data = file_storage.read()
+        dataframe = pd.read_excel(io.BytesIO(data), dtype=str)
+    except ValueError as exc:  # noqa: BLE001
+        raise ValueError('Excel dosyası okunamadı. Lütfen geçerli bir dosya yükleyin.') from exc
+
+    dataframe.columns = [str(col).strip().lower() for col in dataframe.columns]
+    if not REQUIRED_HEADERS.issubset(set(dataframe.columns)):
+        raise ValueError(
+            'Excel başlıkları eksik. Gerekli başlıklar: ad, soyad, okul_numarasi, sinif',
+        )
+
+    dataframe = dataframe.fillna('')
+
+    students: List[Dict[str, str]] = []
+    for row_index, row in enumerate(dataframe.to_dict(orient='records'), start=2):
+        students.append(
+            {
+                'full_name': f"{str(row.get('ad', '')).strip()} {str(row.get('soyad', '')).strip()}".strip(),
+                'student_number': str(row.get('okul_numarasi', '')).strip(),
+                'class_name': str(row.get('sinif', '')).strip(),
+                'source_row': row_index,
+            }
+        )
+
+    if not students:
+        raise ValueError('Excel dosyasında öğrenci verisi bulunamadı.')
     return students

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-SQLAlchemy==3.0.5
 Flask-Login==0.6.3
 pandas==2.1.4
 pdfplumber==0.10.3
+openpyxl==3.1.2
 reportlab==4.0.7
 Werkzeug==2.3.7
 SQLAlchemy==2.0.21


### PR DESCRIPTION
## Summary
- add Excel parsing alongside CSV/PDF import utilities and document the new dependency
- consolidate student import handling to auto-create student user accounts and capture import summaries
- update supervisor student management UI to surface import results and accept Excel uploads

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dce744ece0832b8c9dd54ae8ac004f